### PR TITLE
fix: menu not working

### DIFF
--- a/navbar practise/css/styles.css
+++ b/navbar practise/css/styles.css
@@ -83,7 +83,7 @@ nav {
     .navbar-links li a {
         padding: 0.7rem 1rem;
     }
-    .navbar-links .active {
+    .navbar-links.active {
         display: flex;
     }
 }

--- a/navbar practise/index.html
+++ b/navbar practise/index.html
@@ -10,20 +10,22 @@
   </head>
   <body>
     <nav class="navbar">
-      <div class="brand">Brand Name</div>
+      <div class="container">
+        <div class="brand">Brand Name</div>
 
-      <a href="#" class="toggle-button">
-        <span class="bar"></span>
-        <span class="bar"></span>
-        <span class="bar"></span>
-      </a>
+        <a href="#" class="toggle-button">
+          <span class="bar"></span>
+          <span class="bar"></span>
+          <span class="bar"></span>
+        </a>
 
-      <div class="navbar-links">
-        <ul>
-          <li><a href="#">Home</a></li>
-          <li><a href="#">About</a></li>
-          <li><a href="#">Contact</a></li>
-        </ul>
+        <div class="navbar-links">
+          <ul>
+            <li><a href="#">Home</a></li>
+            <li><a href="#">About</a></li>
+            <li><a href="#">Contact</a></li>
+          </ul>
+        </div>
       </div>
     </nav>
   </body>


### PR DESCRIPTION
`.navbar-links .active` (with spaces between classes) means every element with `.active` class that are child of `.navbar-links`.

As we are trying to add style to elements with `.navbar-links` class that also have an `.active` class, we should concatenate both classes as `.navbar-links.active` (without spaces between classes).

That's was the mistake.